### PR TITLE
Chore/update test

### DIFF
--- a/app/crud/base.py
+++ b/app/crud/base.py
@@ -100,7 +100,7 @@ class CRUDBase(Generic[ModelType, CreateSchemaType, UpdateSchemaType]):
             .where(self.model.id.in_(db_obj_ids))
             .execution_options(populate_existing=True)
         )
-        return db.execute(stmt).scalars().all()
+        return db.execute(stmt).scalars().all() # no mutation so no need to commit
 
     def create_all_using_id(self, db: Session, *, obj_in_list: list[CreateSchemaType]) -> ModelType:
         if not obj_in_list:

--- a/tests/crud/test_base.py
+++ b/tests/crud/test_base.py
@@ -42,7 +42,10 @@ def test_update_obj(db: Session) -> None:
     # update the obj
     new_bool_field = True
     obj_update = EmptyTestUpdate(bool_field=new_bool_field)
-    obj2 = crud.crud_test.update(db=db, db_obj=obj, obj_in=obj_update)
+    crud.crud_test.update(db=db, db_obj=obj, obj_in=obj_update)
+
+    # get the obj again
+    obj2 = crud.crud_test.get(db=db, id=obj.id)
 
     # assert objs are same id but bool_field updated, and other fields unchanged
     assert obj.id == obj2.id
@@ -54,7 +57,10 @@ def test_update_obj_bad_id(db: Session) -> None:
 
     # update the obj that doesn't exist
     obj_update = EmptyTestUpdate(bool_field=True)
-    obj2 = crud.crud_test.update(db=db, db_obj=obj, obj_in=obj_update)
+    crud.crud_test.update(db=db, db_obj=obj, obj_in=obj_update)
+
+    # get the obj again
+    obj2 = crud.crud_test.get(db=db, id=obj.id)
 
     # assert objs are same id but bool_field updated, and other fields unchanged
     assert obj2 is None
@@ -81,7 +87,10 @@ def test_update_obj_refreshes_if_expired(db: Session) -> None:
     new_bool_field = True
     new_title = "t2"
     obj_update = EmptyTestUpdate(bool_field=new_bool_field, title=new_title)
-    new_obj = crud.crud_test.update(db=db, db_obj=obj, obj_in=obj_update)
+    crud.crud_test.update(db=db, db_obj=obj, obj_in=obj_update)
+
+    # get the obj again
+    new_obj = crud.crud_test.get(db=db, id=obj.id)
 
     # assert objs are same id and both original db object and new one have been refreshed
     assert obj.id == new_obj.id


### PR DESCRIPTION
Fixed tests to catch the bug where `update` returns an object that looks updated, but the database didn't actually have a commit to mutate the data.