### PR TITLE
feat/get-endpoints: endpoints to get latest pretrained model and set originated_from

### DIFF
--- a/app/aimodels/bertopic/models/bertopic_embedding_pretrained.py
+++ b/app/aimodels/bertopic/models/bertopic_embedding_pretrained.py
@@ -1,10 +1,10 @@
 import enum
+import uuid
 from typing import TYPE_CHECKING
 from sqlalchemy import Column, Enum, Integer, UUID, String, Boolean, Sequence
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
-from app.core.config import OriginationEnum
-import uuid
+from app.core.config import OriginationEnum, get_originated_from
 
 if TYPE_CHECKING:
     from .document_embedding_computation import DocumentEmbeddingComputationModel  # noqa: F401
@@ -23,6 +23,6 @@ class BertopicEmbeddingPretrainedModel(Base):
     version = Column(Integer, version_sequence, server_default=version_sequence.next_value(), index=True, unique=True, nullable=False)
     sha256 = Column(String(64))
     uploaded = Column(Boolean(), default=False)
-    originated_from = Column(Enum(OriginationEnum), default=OriginationEnum.ORIGINATED_FROM_APP)
+    originated_from = Column(Enum(OriginationEnum), default=get_originated_from)
     document_embedding_computations = relationship("DocumentEmbeddingComputationModel", back_populates="bertopic_embedding_pretrained")
     trained_models = relationship("BertopicTrainedModel", back_populates="embedding_pretrained")

--- a/app/aimodels/bertopic/models/bertopic_embedding_pretrained.py
+++ b/app/aimodels/bertopic/models/bertopic_embedding_pretrained.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, Enum, Integer, UUID, String, Boolean, Sequence
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
+from app.core.config import OriginationEnum
 import uuid
 
 if TYPE_CHECKING:
@@ -22,5 +23,6 @@ class BertopicEmbeddingPretrainedModel(Base):
     version = Column(Integer, version_sequence, server_default=version_sequence.next_value(), index=True, unique=True, nullable=False)
     sha256 = Column(String(64))
     uploaded = Column(Boolean(), default=False)
+    originated_from = Column(Enum(OriginationEnum), default=OriginationEnum.ORIGINATED_FROM_APP)
     document_embedding_computations = relationship("DocumentEmbeddingComputationModel", back_populates="bertopic_embedding_pretrained")
     trained_models = relationship("BertopicTrainedModel", back_populates="embedding_pretrained")

--- a/app/aimodels/bertopic/models/bertopic_trained.py
+++ b/app/aimodels/bertopic/models/bertopic_trained.py
@@ -1,7 +1,8 @@
 from typing import TYPE_CHECKING
-from sqlalchemy import Boolean, Column, ForeignKey, UUID, JSON
+from sqlalchemy import Boolean, Column, ForeignKey, UUID, JSON, Enum
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
+from app.core.config import OriginationEnum, get_originated_from
 import uuid
 
 if TYPE_CHECKING:
@@ -14,5 +15,6 @@ class BertopicTrainedModel(Base):
     uploaded = Column(Boolean(), default=False)
     plotly_bubble_config = Column(JSON)
     embedding_pretrained_id = Column(UUID, ForeignKey("bertopicembeddingpretrainedmodel.id"))
+    originated_from = Column(Enum(OriginationEnum), default=get_originated_from)
     embedding_pretrained = relationship("BertopicEmbeddingPretrainedModel", back_populates="trained_models")
     trained_on_documents = relationship("DocumentModel", secondary="documentbertopictrainedmodel", back_populates="used_in_trained_models")

--- a/app/aimodels/bertopic/models/document.py
+++ b/app/aimodels/bertopic/models/document.py
@@ -1,8 +1,9 @@
 from typing import TYPE_CHECKING
-from sqlalchemy import Column, DateTime, UUID, String
+from sqlalchemy import Column, DateTime, UUID, String, Enum
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from app.db.base_class import Base
+from app.core.config import OriginationEnum, get_originated_from
 import uuid
 
 if TYPE_CHECKING:
@@ -14,6 +15,7 @@ class DocumentModel(Base):
     # pylint: disable=not-callable
     original_created_time = Column(DateTime(timezone=True), server_default=func.now()) # see sqlalchemy datetime info here: https://stackoverflow.com/questions/13370317/sqlalchemy-default-datetime
     text = Column(String)
+    originated_from = Column(Enum(OriginationEnum), default=get_originated_from)
     embedding_computations = relationship("DocumentEmbeddingComputationModel", back_populates="document")
     used_in_trained_models = relationship("BertopicTrainedModel", secondary="documentbertopictrainedmodel", back_populates="trained_on_documents")
     # TODO: have a mattermost "post" entity save a document ID in a "1-to-1" manner, but dont relate...try to make modular

--- a/app/aimodels/bertopic/models/document_bertopic_trained_model.py
+++ b/app/aimodels/bertopic/models/document_bertopic_trained_model.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
-from sqlalchemy import Column, ForeignKey, Table
+from sqlalchemy import Column, ForeignKey, Table, Enum
 from app.db.base_class import Base
+from app.core.config import OriginationEnum, get_originated_from
 
 if TYPE_CHECKING:
     from .document import DocumentModel  # noqa: F401

--- a/app/aimodels/bertopic/models/document_embedding_computation.py
+++ b/app/aimodels/bertopic/models/document_embedding_computation.py
@@ -1,8 +1,9 @@
 import uuid
 from typing import TYPE_CHECKING
-from sqlalchemy import Column, UUID, Float, ARRAY, ForeignKey
+from sqlalchemy import Column, UUID, Float, ARRAY, ForeignKey, Enum
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
+from app.core.config import OriginationEnum, get_originated_from
 
 if TYPE_CHECKING:
     from .bertopic_embedding_pretrained import BertopicEmbeddingPretrainedModel  # noqa: F401
@@ -15,3 +16,4 @@ class DocumentEmbeddingComputationModel(Base):
     document = relationship("DocumentModel", back_populates="embedding_computations")
     bertopic_embedding_pretrained_id = Column(UUID, ForeignKey("bertopicembeddingpretrainedmodel.id"))
     bertopic_embedding_pretrained = relationship("BertopicEmbeddingPretrainedModel", back_populates="document_embedding_computations")
+    originated_from = Column(Enum(OriginationEnum), default=get_originated_from)

--- a/app/aimodels/bertopic/routers/bertopic_embedding_pretrained.py
+++ b/app/aimodels/bertopic/routers/bertopic_embedding_pretrained.py
@@ -1,4 +1,3 @@
-import os
 import hashlib
 from typing import Union
 from fastapi import Depends, APIRouter, UploadFile

--- a/app/aimodels/bertopic/routers/bertopic_embedding_pretrained.py
+++ b/app/aimodels/bertopic/routers/bertopic_embedding_pretrained.py
@@ -17,12 +17,11 @@ from sqlalchemy.orm import Session
 from .. import crud
 from ..ai_services.basic_inference import BASE_CKPT_DIR
 from ..models.bertopic_embedding_pretrained import BertopicEmbeddingPretrainedModel
+
 from app.core.errors import HTTPValidationError, ValidationError
 from aiofiles import open as open_aio
 from minio import Minio
 from minio.error import InvalidResponseError
-
-from app.core.config import settings
 
 
 router = APIRouter(
@@ -101,3 +100,26 @@ async def upload_bertopic_embedding_post(new_file: UploadFile, id: UUID4, db: Se
         db, db_obj=bertopic_embedding_pretrained_obj, obj_in=BertopicEmbeddingPretrainedUpdate(uploaded=True))
 
     return new_bertopic_embedding_pretrained_obj
+
+@router.get(
+    "/",
+    response_model=Union[BertopicEmbeddingPretrained, HTTPValidationError],
+    responses={'422': {'model': HTTPValidationError}},
+    summary="Get latest uploaded BERTopic Embedding Pretrained Model object",
+    response_description="Retrieved latest Embedding Pretrained Model object"
+)
+def get_latest_bertopic_embedding_pretrained_object(model_name: str, db: Session = Depends(get_db)) -> (
+    Union[BertopicEmbeddingPretrained, HTTPValidationError]
+):
+    """
+    Get latest uploaded BERTopic Embedding Pretrained Model object.
+    """
+    bertopic_embedding_pretrained_obj = db.query(BertopicEmbeddingPretrainedModel).filter(
+        BertopicEmbeddingPretrainedModel.model_name == model_name,
+        BertopicEmbeddingPretrainedModel.uploaded).order_by(
+        BertopicEmbeddingPretrainedModel.version.desc()).first()
+
+    if not bertopic_embedding_pretrained_obj:
+        raise HTTPException(status_code=422, detail="BERTopic Embedding Pretrained Model not found")
+
+    return bertopic_embedding_pretrained_obj

--- a/app/aimodels/bertopic/routers/train.py
+++ b/app/aimodels/bertopic/routers/train.py
@@ -13,6 +13,7 @@ from .. import crud
 from ..models.bertopic_trained import BertopicTrainedModel
 from ..schemas.bertopic_trained import BertopicTrainedCreate
 from app.core.errors import ValidationError, HTTPValidationError
+from app.core.config import settings
 from ..models.bertopic_embedding_pretrained import BertopicEmbeddingPretrainedModel
 
 router = APIRouter(
@@ -88,7 +89,8 @@ def train_bertopic_post(request: TrainModelRequest, db: Session = Depends(get_db
     new_embedding_computation_obj_list = [DocumentEmbeddingComputationCreate(
         document_id=documents[i].id,
         bertopic_embedding_pretrained_id=request.sentence_transformer_id,
-        embedding_vector=inference_output.embeddings[i]
+        embedding_vector=inference_output.embeddings[i], 
+        originated_from=settings.originated_from
     ) for i, wasUpdated in enumerate(inference_output.updated_document_indicies) if wasUpdated]
 
     crud.document_embedding_computation.create_all_using_id(

--- a/app/aimodels/bertopic/schemas/bertopic_embedding_pretrained.py
+++ b/app/aimodels/bertopic/schemas/bertopic_embedding_pretrained.py
@@ -1,9 +1,9 @@
 import re
 from typing import Optional
+from app.core.config import OriginationEnum
 
 from pydantic import BaseModel, UUID4, validator
 from ..models.bertopic_embedding_pretrained import EmbeddingModelTypeEnum
-from app.core.config import settings, OriginationEnum
 
 # Shared properties
 class BertopicEmbeddingPretrainedBase(BaseModel):
@@ -30,7 +30,6 @@ class BertopicEmbeddingPretrainedBase(BaseModel):
 class BertopicEmbeddingPretrainedCreate(BertopicEmbeddingPretrainedBase):
     sha256: str
     model_name: str = ''
-    originated_from: OriginationEnum = settings.originated_from
 
 # Properties to receive on BertopicEmbeddingPretrained update
 class BertopicEmbeddingPretrainedUpdate(BertopicEmbeddingPretrainedBase):

--- a/app/aimodels/bertopic/schemas/bertopic_embedding_pretrained.py
+++ b/app/aimodels/bertopic/schemas/bertopic_embedding_pretrained.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel, UUID4, validator
 from ..models.bertopic_embedding_pretrained import EmbeddingModelTypeEnum
+from app.core.config import settings, OriginationEnum
 
 # Shared properties
 class BertopicEmbeddingPretrainedBase(BaseModel):
@@ -29,6 +30,7 @@ class BertopicEmbeddingPretrainedBase(BaseModel):
 class BertopicEmbeddingPretrainedCreate(BertopicEmbeddingPretrainedBase):
     sha256: str
     model_name: str = ''
+    originated_from: OriginationEnum = settings.originated_from
 
 # Properties to receive on BertopicEmbeddingPretrained update
 class BertopicEmbeddingPretrainedUpdate(BertopicEmbeddingPretrainedBase):
@@ -42,6 +44,7 @@ class BertopicEmbeddingPretrainedInDBBase(BertopicEmbeddingPretrainedBase):
     uploaded: bool = False
     version: int
     sha256: str
+    originated_from: OriginationEnum
 
     class Config:
         orm_mode = True

--- a/app/aimodels/bertopic/schemas/bertopic_trained.py
+++ b/app/aimodels/bertopic/schemas/bertopic_trained.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from app.core.config import OriginationEnum
 
 from pydantic import BaseModel, UUID4
 
@@ -22,6 +23,7 @@ class BertopicTrainedUpdate(BertopicTrainedBase):
 class BertopicTrainedInDBBase(BertopicTrainedBase):
     id: UUID4
     embedding_pretrained_id: UUID4
+    originated_from: OriginationEnum
 
     class Config:
         orm_mode = True

--- a/app/aimodels/bertopic/schemas/document.py
+++ b/app/aimodels/bertopic/schemas/document.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pydantic import BaseModel, UUID4
+from app.core.config import OriginationEnum
 
 # Shared properties
 class DocumentBase(BaseModel):
@@ -13,6 +14,7 @@ class DocumentCreate(DocumentBase):
 class DocumentInDBBase(DocumentBase):
     id: UUID4
     original_created_time: datetime
+    originated_from: OriginationEnum
 
     class Config:
         orm_mode = True

--- a/app/aimodels/bertopic/schemas/document_embedding_computation.py
+++ b/app/aimodels/bertopic/schemas/document_embedding_computation.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from app.core.config import OriginationEnum
 
 from pydantic import BaseModel, UUID4
 
@@ -22,6 +23,7 @@ class DocumentEmbeddingComputationInDBBase(DocumentEmbeddingComputationBase):
     id: UUID4
     document_id: UUID4
     bertopic_embedding_pretrained_id: UUID4
+    originated_from: OriginationEnum
 
     class Config:
         orm_mode = True

--- a/app/aimodels/gpt4all/models/gpt4all_pretrained.py
+++ b/app/aimodels/gpt4all/models/gpt4all_pretrained.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, Enum, Integer, UUID, String, Boolean, Sequence
 from sqlalchemy.orm import relationship
 from app.db.base_class import Base
+from app.core.config import OriginationEnum, get_originated_from
 import uuid
 
 # add in the TYPE_CHECKING check here if relationships are created
@@ -18,3 +19,4 @@ class Gpt4AllPretrainedModel(Base):
     sha256 = Column(String(64))
     uploaded = Column(Boolean(), default=False)
     use_base_model = Column(Boolean(), default=False)
+    originated_from = Column(Enum(OriginationEnum), default=get_originated_from)

--- a/app/aimodels/gpt4all/schemas/gpt4all_pretrained.py
+++ b/app/aimodels/gpt4all/schemas/gpt4all_pretrained.py
@@ -1,5 +1,6 @@
 import re
 from typing import Optional
+from app.core.config import OriginationEnum
 
 from pydantic import BaseModel, UUID4, validator
 from ..models.gpt4all_pretrained import Gpt4AllModelFilenameEnum
@@ -42,6 +43,7 @@ class Gpt4AllPretrainedInDBBase(Gpt4AllPretrainedBase):
     version: int
     sha256: str
     use_base_model: bool
+    originated_from: OriginationEnum
 
     class Config:
         orm_mode = True

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,11 @@
 import os
+import enum
 from typing import Optional, Any
 from pydantic import BaseSettings, PostgresDsn, validator
+
+class OriginationEnum(str, enum.Enum):
+    ORIGINATED_FROM_APP = "app"
+    ORIGINATED_FROM_TEST = "test"
 
 # load the environment name, local, test, staging, or production
 class EnvironmentSettings(BaseSettings):
@@ -11,6 +16,7 @@ class Settings(BaseSettings):
     # general settings
     docs_ui_root_path: str = ""
     log_level: str = "INFO"
+    originated_from: str = OriginationEnum.ORIGINATED_FROM_APP
 
     # minio settings
     minio_bucket_name: str = ""

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     # general settings
     docs_ui_root_path: str = ""
     log_level: str = "INFO"
-    originated_from: str = OriginationEnum.ORIGINATED_FROM_APP
+    originated_from: OriginationEnum = OriginationEnum.ORIGINATED_FROM_APP
 
     # minio settings
     minio_bucket_name: str = ""
@@ -89,7 +89,9 @@ def get_env_file(environment_settings_in):
 
     return env_file
 
-
 environment_settings = EnvironmentSettings()
 settings = Settings(_env_file=get_env_file(
     environment_settings), _env_file_encoding='utf-8')
+
+def get_originated_from():
+    return settings.originated_from

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi_versioning import VersionedFastAPI
-from .core.config import settings
+from .core.config import settings, OriginationEnum
 from .core.logging import logger, LogConfig
 from logging.config import dictConfig
 from .aimodels.router import router as aimodels_router
@@ -35,6 +35,18 @@ origins = [
     "https://transformers.staging.dso.mil",
     "https://transformers.apps.dso.mil",
 ]
+
+# set originated_from for standard app usage
+@app.get('/originated_from_app/')
+async def originated_from_app():
+    settings.originated_from = OriginationEnum.ORIGINATED_FROM_APP
+    return settings.originated_from
+
+# use test to allow for cleanup of database entries
+@app.get('/originated_from_test/')
+async def originated_from_test():
+    settings.originated_from = OriginationEnum.ORIGINATED_FROM_TEST
+    return settings.originated_from
 
 app.include_router(aimodels_router)
 app.include_router(sentiments_router)

--- a/tests/aimodels/bertopic/routers/test_bertopic_embedding_pretrained.py
+++ b/tests/aimodels/bertopic/routers/test_bertopic_embedding_pretrained.py
@@ -278,3 +278,41 @@ def test_upload_bertopic_embedding_pretrained_weak_learner_object_post_valid_req
 
     assert response2.status_code == 200
     assert response2.json()["uploaded"] is True
+
+
+def test_get_latest_bertopic_embedding_pretrained_object_invalid_request(client: TestClient):
+    body = {'wrong_param': 'does not matter'}
+
+    response = client.get(
+        "/aimodels/bertopic/bertopic-embedding-pretrained",
+        headers={},
+        params=jsonable_encoder(body)
+    )
+
+    assert response.status_code == 422
+
+
+def test_get_latest_bertopic_embedding_pretrained_object_invalid_name(client: TestClient):
+    body = {'model_name': 'nonexistent_model'}
+
+    response = client.get(
+        "/aimodels/bertopic/bertopic-embedding-pretrained",
+        headers={},
+        params=jsonable_encoder(body)
+    )
+
+    assert response.status_code == 422
+
+
+def test_get_latest_bertopic_embedding_pretrained_object_valid_name(client: TestClient):
+    my_model = 'test'
+    body = {'model_name': my_model}
+
+    response = client.get(
+        "/aimodels/bertopic/bertopic-embedding-pretrained",
+        headers={},
+        params=jsonable_encoder(body)
+    )
+
+    assert response.status_code == 200
+    assert response.json()['model_name'] == my_model

--- a/tests/aimodels/bertopic/routers/test_documents.py
+++ b/tests/aimodels/bertopic/routers/test_documents.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from app.aimodels.bertopic.schemas.document import DocumentCreate
 
 from app.main import app
+from app.core.config import OriginationEnum
 from app.aimodels.bertopic.routers.documents import get_db
 from tests.test_files.db.db_test_session import SessionLocal
 
@@ -35,6 +36,10 @@ def test_create_document_object_post_valid_request(client: TestClient):
     assert response.json()[0]['id'] is not None
     assert response.json()[0]['original_created_time'] is not None
     assert response.json()[0]['text'] == "This is a test document"
+
+    # extend test_set_originated_from_* to confirm originated_from set properly in db
+    # originated_from_test called in pytest client fixture
+    assert response.json()[0]['originated_from'] == OriginationEnum.ORIGINATED_FROM_TEST
 
 def test_create_document_object_post_invalid_request(client: TestClient):
     body = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from .test_files.db.db_test_session import SessionLocal
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
+from app.core.config import OriginationEnum
 
 
 # in case you are wondering why we use yield instead of return, check this
@@ -12,10 +13,13 @@ from app.main import app
 def db() -> Generator:
     yield SessionLocal()
 
-
 @pytest.fixture(scope="module")
 def client() -> Generator:
     with TestClient(app) as c:
+        response = c.get("/originated_from_test/")
+        data = response.json()
+        assert data == OriginationEnum.ORIGINATED_FROM_TEST
+        assert response.status_code == 200
         yield c
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def db() -> Generator:
 @pytest.fixture(scope="module")
 def client() -> Generator:
     with TestClient(app) as c:
+        # initialize originated_from to test to allow for db cleanup 
         response = c.get("/originated_from_test/")
         data = response.json()
         assert data == OriginationEnum.ORIGINATED_FROM_TEST

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from app.main import versioned_app
+from app.core.config import OriginationEnum
 
 client = TestClient(versioned_app)
 
@@ -8,4 +9,18 @@ def test_v1_exists():
     response = client.get(
         "/v1/docs"
     )
+    assert response.status_code == 200
+
+# set originated_from for standard app usage
+def test_set_originated_from_app():
+    response = client.get("/v1/originated_from_app")
+    data = response.json()
+    assert data == OriginationEnum.ORIGINATED_FROM_APP
+    assert response.status_code == 200
+
+# set originated_from for cleanup of database test entries
+def test_set_originated_from_test():
+    response = client.get("/v1/originated_from_test")
+    data = response.json()
+    assert data == OriginationEnum.ORIGINATED_FROM_TEST
     assert response.status_code == 200


### PR DESCRIPTION
endpoints to get latest pretrained model and set originated_from, includes:
- updates to bertopic and gpt4all schemas to set originated_from (defaults to app)
- update to pytest client fixture to originated_from=test for all tests

98 pytests passing; 85% coverage