### PR TITLE
add root_id to mattermost_document schema

### DIFF
--- a/app/mattermost/models/mattermost_documents.py
+++ b/app/mattermost/models/mattermost_documents.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class MattermostDocumentModel(Base):
     id = Column(UUID, primary_key=True, unique=True, default=uuid.uuid4)
     message_id = Column(String(), unique=True)
+    root_message_id = Column(String())
     channel = Column(UUID, ForeignKey("mattermostchannelmodel.id"))
     user = Column(UUID, ForeignKey("mattermostusermodel.id"))
     document = Column(UUID, ForeignKey("documentmodel.id"))

--- a/app/mattermost/router.py
+++ b/app/mattermost/router.py
@@ -126,6 +126,7 @@ async def upload_mm_channel_docs(channel_ids: list[str], db: Session = Depends(g
 
         mattermost_documents = mattermost_documents + [MattermostDocumentCreate(
             message_id=row['id'],
+            root_message_id=row['root_id'],
             channel=row['channel'],
             user=row['user'],
             document=document_obj.id)]

--- a/app/mattermost/schemas/mattermost_documents.py
+++ b/app/mattermost/schemas/mattermost_documents.py
@@ -5,6 +5,7 @@ from app.core.config import OriginationEnum
 # Shared properties
 class MattermostDocumentBase(BaseModel):
     message_id: str
+    root_message_id: str
     channel: UUID4
     user: UUID4
     document: UUID4

--- a/tests/mattermost/test_mattermost_router.py
+++ b/tests/mattermost/test_mattermost_router.py
@@ -23,7 +23,7 @@ def test_upload_mattermost_user_info_invalid_input():
     )
 
     assert response.status_code == 422
-    # assert 'Mattermost' in response.json()['detail'] FIXME
+    assert 'Mattermost' in response.json()['detail']
 
 # returns 422
 def test_get_mattermost_user_info_invalid_format():
@@ -52,11 +52,11 @@ def test_upload_mattermost_documents_invalid_format():
     response = client.post(
         "/mattermost/documents/upload",
         headers={},
-        json={"notafield": "notachannelid1"}
+        json={"notafield": "notachannelid"}
     )
 
     assert response.status_code == 422
-    # assert response.json()['detail'][0]['msg'] == 'field required' FIXME
+    assert 'Mattermost' in response.json()['detail']
 
 # returns 422
 def test_upload_mattermost_documents_invalid_input():
@@ -67,7 +67,7 @@ def test_upload_mattermost_documents_invalid_input():
     )
 
     assert response.status_code == 422
-    # assert 'Mattermost' in response.json()['detail'] FIXME
+    assert 'Mattermost' in response.json()['detail']
 
 # returns 422
 def test_get_mattermost_documents_invalid_format():


### PR DESCRIPTION
Feat/mattermost (#41)
- add root_id to mattermost document schema
- mattermost post endpoint validation
- 106 tests passing, 88% coverage without bertopic/train integration tests