### PR TITLE
chore/more-tests-for-staging

### DIFF
--- a/app/aimodels/bertopic/routers/train.py
+++ b/app/aimodels/bertopic/routers/train.py
@@ -161,6 +161,8 @@ def train_bertopic_post(request: TrainModelRequest, db: Session = Depends(get_db
     # (see docs here for info: https://docs.sqlalchemy.org/en/20/orm/session_state_management.html#refreshing-expiring)
     db.refresh(new_bertopic_trained_obj)
 
+    [crud.topic_summary.update(db, db_obj=topic, obj_in=TopicSummaryUpdate(
+        model_id=new_bertopic_trained_obj.id)) for topic in inference_output.topics]
 
     return new_bertopic_trained_obj
 

--- a/app/core/env_var/staging.env
+++ b/app/core/env_var/staging.env
@@ -13,7 +13,7 @@ MINIO_SECURE=False
 
 DOCS_UI_ROOT_PATH="/api"
 LOG_LEVEL="INFO"
-MM_BASE_URL="https://chat.preprod.dso.mil"
+MM_BASE_URL="https://chat.il4.dso.mil"
 MM_AOC_BASE_URL="${MM_BASE_URL}/usaf-618aoc-mod"
 MM_NITMRE_BASE_URL="${MM_BASE_URL}/nitmre"
 

--- a/app/initial_data.py
+++ b/app/initial_data.py
@@ -50,8 +50,8 @@ def init() -> None:
 def get_db(environment: str, migration_toggle: bool) -> Union[Session, None]:
     db = None
 
-    # clear DB if local or staging as long as not actively testing migrating
-    if (environment in ['local', 'staging'] and migration_toggle is False):
+    clear DB if local or staging as long as not actively testing migrating
+    if (environment in ['local'] and migration_toggle is False):
         logger.info("Clearing database")
         wipe_db()
         logger.info("Database cleared")

--- a/tests/mattermost/test_mattermost_crud.py
+++ b/tests/mattermost/test_mattermost_crud.py
@@ -10,29 +10,39 @@ from app.aimodels.bertopic.models.document import DocumentModel
 from app.aimodels.bertopic.crud import crud_document
 
 
-# test crud mattermost
 def test_crud_mattermost(db: Session):
+    # test crud mattermost
 
     # test mattermost channel
-    channel_info = dict({'id': str(uuid.uuid4()), 'name': 'my channel', 'team_id': str(uuid.uuid4()), 'team_name': 'my team'})
-    channel_db_obj = crud.populate_mm_channel_info(db, channel_info=channel_info)
+    channel_info = dict({'id': str(uuid.uuid4()), 'name': 'my channel', 'team_id': str(
+        uuid.uuid4()), 'team_name': 'my team'})
+    channel_db_obj = crud.populate_mm_channel_info(
+        db, channel_info=channel_info)
 
     assert channel_db_obj.channel_id == channel_info['id']
     assert channel_db_obj.channel_name == channel_info['name']
     assert channel_db_obj.team_id == channel_info['team_id']
     assert channel_db_obj.team_name == channel_info['team_name']
-    assert crud.mattermost_channels.get_by_channel_id(db, channel_id=channel_info['id']) is not None
+    assert crud.mattermost_channels.get_by_channel_id(
+        db, channel_id=channel_info['id']) is not None
+    assert crud.mattermost_channels.get_by_channel_name(
+        db, team_name=channel_info['team_name'], channel_name=channel_info['name']) is not None
+    assert channel_info['id'] in crud.mattermost_channels.get_all_channel_ids(
+        db)
 
     # test mattermost user
     user = str(uuid.uuid4())
     mm_user = dict({'id': user, 'username': user})
-    teams=dict({'0': 'a team', '1': 'another team'})
+    teams = dict({'0': 'a team', '1': 'another team'})
     user_db_obj = crud.populate_mm_user_info(db, mm_user=mm_user, teams=teams)
 
     assert user_db_obj.user_id == mm_user['id']
     assert user_db_obj.user_name == mm_user['username']
     assert user_db_obj.teams == teams
-    assert crud.mattermost_users.get_by_user_id(db, user_id=mm_user['id']) is not None
+    assert crud.mattermost_users.get_by_user_id(
+        db, user_id=mm_user['id']) is not None
+    assert crud.mattermost_users.get_by_user_name(
+        db, user_name=mm_user['username']) is not None
 
     # test mattermost document
     doc_db_obj = crud_document.document.create(db,
@@ -52,11 +62,16 @@ def test_crud_mattermost(db: Session):
     assert db_obj.root_message_id == obj_in.root_message_id
     assert db_obj.channel == obj_in.channel
     assert db_obj.user == obj_in.user
-    assert crud.mattermost_documents.get_by_message_id(db, message_id=obj_in.message_id) is not None
+    assert crud.mattermost_documents.get_by_message_id(
+        db, message_id=obj_in.message_id) is not None
+    assert crud.mattermost_documents.get_all_channel_documents(
+        db, channels=[obj_in.channel]) is not None
+    assert not crud.mattermost_documents.get_document_dataframe(
+        db, document_uuids=[db_obj.id]).empty
 
 
-# test user info in database
-def test_populate_mm_user_team_info(db: Session):
+def test_populate_mm_user_team_info_local(db: Session):
+    # test user info in database
 
     if environment_settings.environment == 'test':
         return
@@ -67,6 +82,24 @@ def test_populate_mm_user_team_info(db: Session):
     assert user_obj.user_name == mm_name
 
 
+def test_populate_mm_user_team_info(db: Session, mocker):
+    # test user info in database
+
+    # mock mattermost_utils for staging pipeline
+    user = str(uuid.uuid4())
+    mock_user_data = (dict({'id': user, 'username': user}), pd.DataFrame())
+    mocker.patch(
+        'app.mattermost.services.mattermost_utils.get_user_info', return_value=mock_user_data)
+
+    mock_team_data = pd.DataFrame()
+    mocker.patch('app.mattermost.services.mattermost_utils.get_team_channels', return_value=mock_team_data)
+    mocker.patch('app.mattermost.services.mattermost_utils.get_all_user_channels', return_value=mock_team_data)
+
+    user_obj = crud.populate_mm_user_team_info(db, user_name=user)
+
+    assert user_obj.user_name == user
+
+
 def test_convert_conversation_threads():
 
     msg1 = 'message 1.'
@@ -74,11 +107,12 @@ def test_convert_conversation_threads():
 
     # construct message data frame with reply and convert to conversation thread
     document_df = pd.DataFrame()
-    document_df = pd.concat([document_df,  pd.DataFrame([{'id': '1', 'message': msg1, 'root_id': ''}])])
-    document_df = pd.concat([document_df,  pd.DataFrame([{'id': '2', 'message': msg2, 'root_id': '1'}])])
+    document_df = pd.concat([document_df,  pd.DataFrame(
+        [{'id': '1', 'message': msg1, 'root_id': ''}])])
+    document_df = pd.concat([document_df,  pd.DataFrame(
+        [{'id': '2', 'message': msg2, 'root_id': '1'}])])
 
     conversation_df = crud.convert_conversation_threads(document_df)
 
     assert len(conversation_df) == (len(document_df) - 1)
     assert conversation_df['message'].iloc[0] == '%s\n%s' % (msg1, msg2)
-

--- a/tests/mattermost/test_mattermost_utils.py
+++ b/tests/mattermost/test_mattermost_utils.py
@@ -1,9 +1,11 @@
+import uuid
+import pandas as pd
+from unittest.mock import patch, Mock, create_autospec
 from app.core.config import settings, environment_settings
 from app.mattermost.services import mattermost_utils
 
-
-# test mattermost api calls for user, team, and channel info
 def test_mattermost_bot():
+# test mattermost api calls for user, team, and channel info
 
     if environment_settings.environment == 'test':
         return
@@ -31,3 +33,31 @@ def test_mattermost_bot():
         settings.mm_base_url, settings.mm_token, channels['id'].iloc[0])
 
     assert not documents.empty
+
+
+def test_get_user_info(mocker):
+# pipeline safe test for get_user_info
+
+    user = str(uuid.uuid4())
+    mock_data = (dict({'id': user, 'username': user}), pd.DataFrame())
+
+    mocker.patch('app.mattermost.services.mattermost_utils.get_user_info', return_value=mock_data)
+
+    user_info = mattermost_utils.get_user_info("127.0.0.1", "a_token", user)
+
+    assert user_info == mock_data
+
+
+def test_get_all_user_channels(mocker):
+# pipeline safe test for get_all_user_channels
+
+    user = str(uuid.uuid4())
+    team = str(uuid.uuid4())
+    mock_data = pd.DataFrame()
+
+    mocker.patch('app.mattermost.services.mattermost_utils.get_team_channels', return_value=mock_data)
+    mocker.patch('app.mattermost.services.mattermost_utils.get_all_user_channels', return_value=mock_data)
+
+    channel_info = mattermost_utils.get_all_user_channels("127.0.0.1", "a_token", user, [team])
+
+    assert channel_info.equals(mock_data)


### PR DESCRIPTION
- some mattermost mocks for staging tests
- undo pr #66 removal of topic summary update trained model id
- disable wipe_db for staging to allow db objects to persist between deployments