### PR TITLE
urllib3 update, modify ngrams, handle mm pagination

### DIFF
--- a/app/aimodels/bertopic/ai_services/basic_inference.py
+++ b/app/aimodels/bertopic/ai_services/basic_inference.py
@@ -172,7 +172,7 @@ class BasicInference:
         self.sentence_transformer_obj = sentence_transformer_obj
 
         self.vectorizer = CountVectorizer(
-            stop_words="english", ngram_range=(1, 2))
+            stop_words="english", ngram_range=(1, 3))
 
         self.weak_learner_obj = weak_learner_obj
         self.label_model = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -1108,21 +1108,19 @@ files = [
 
 [[package]]
 name = "google-auth"
-version = "2.22.0"
+version = "2.23.4"
 description = "Google Authentication Library"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "google-auth-2.22.0.tar.gz", hash = "sha256:164cba9af4e6e4e40c3a4f90a1a6c12ee56f14c0b4868d1ca91b32826ab334ce"},
-    {file = "google_auth-2.22.0-py2.py3-none-any.whl", hash = "sha256:d61d1b40897407b574da67da1a833bdc10d5a11642566e506565d1b1a46ba873"},
+    {file = "google-auth-2.23.4.tar.gz", hash = "sha256:79905d6b1652187def79d491d6e23d0cbb3a21d3c7ba0dbaa9c8a01906b13ff3"},
+    {file = "google_auth-2.23.4-py2.py3-none-any.whl", hash = "sha256:d4bbc92fe4b8bfd2f3e8d88e5ba7085935da208ee38a134fc280e7ce682a05f2"},
 ]
 
 [package.dependencies]
 cachetools = ">=2.0.0,<6.0"
 pyasn1-modules = ">=0.2.1"
 rsa = ">=3.1.4,<5"
-six = ">=1.9.0"
-urllib3 = "<2.0"
 
 [package.extras]
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0.dev0)", "requests (>=2.20.0,<3.0.0.dev0)"]
@@ -4717,19 +4715,20 @@ plot = ["bokeh", "colorcet", "datashader", "holoviews", "matplotlib", "pandas", 
 
 [[package]]
 name = "urllib3"
-version = "1.26.17"
+version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = ">=3.7"
 files = [
-    {file = "urllib3-1.26.17-py2.py3-none-any.whl", hash = "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"},
-    {file = "urllib3-1.26.17.tar.gz", hash = "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21"},
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
 ]
 
 [package.extras]
-brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "uvicorn"
@@ -4974,4 +4973,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.11"
-content-hash = "ede6244da4736d50eba30dba2c6b33c406a05b9d9f6b03653dd620c2ef5bd43b"
+content-hash = "e0d4e36370f4572774885beba081e8e9f5d98a094b761f4df49b2ce61c3e3da2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "app"}]
 
 [tool.poetry.dependencies]
 python = "~3.11"
-urllib3 = "1.26.17"
+urllib3 = "2.0.7"
 fastapi = "^0.95.2"
 uvicorn = "^0.22.0"
 pydantic = "^1.10.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ fsspec==2023.6.0 ; python_version >= "3.11" and python_version < "3.12"
 gast==0.4.0 ; python_version >= "3.11" and python_version < "3.12" and (platform_machine == "x86_64" or platform_machine == "arm64") and (platform_machine == "x86_64" or sys_platform == "darwin")
 glibc==0.6.1 ; python_version >= "3.11" and python_version < "3.12"
 google-auth-oauthlib==1.0.0 ; python_version >= "3.11" and python_version < "3.12"
-google-auth==2.22.0 ; python_version >= "3.11" and python_version < "3.12"
+google-auth==2.23.4 ; python_version >= "3.11" and python_version < "3.12"
 google-pasta==0.2.0 ; python_version >= "3.11" and python_version < "3.12" and (platform_machine == "x86_64" or platform_machine == "arm64") and (platform_machine == "x86_64" or sys_platform == "darwin")
 gpt4all==1.0.8 ; python_version >= "3.11" and python_version < "3.12"
 greenlet==2.0.2 ; python_version >= "3.11" and python_version < "3.12" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
@@ -148,7 +148,7 @@ typing-extensions==4.2.0 ; python_version >= "3.11" and python_version < "3.12"
 typing-inspect==0.9.0 ; python_version >= "3.11" and python_version < "3.12"
 tzdata==2023.3 ; python_version >= "3.11" and python_version < "3.12"
 umap-learn==0.5.3 ; python_version >= "3.11" and python_version < "3.12"
-urllib3==1.26.17 ; python_version >= "3.11" and python_version < "3.12"
+urllib3==2.0.7 ; python_version >= "3.11" and python_version < "3.12"
 uvicorn==0.22.0 ; python_version >= "3.11" and python_version < "3.12"
 werkzeug==3.0.1 ; python_version >= "3.11" and python_version < "3.12"
 wheel==0.41.2 ; python_version >= "3.11" and python_version < "3.12"


### PR DESCRIPTION
- update urllib3 for CVE-2023-45803
- update ngrams to (1,3) in countvectorizer: https://github.com/orgs/MIT-AI-Accelerator/projects/2/views/1?pane=issue&itemId=44168136
- handle mattermost pagination issue: https://github.com/orgs/MIT-AI-Accelerator/projects/2/views/1?pane=issue&itemId=44346553
- confirmed app startup and pytests passing locally