### PR TITLE
Fix unreachable fix_text logic and add associated tests.

### DIFF
--- a/app/aimodels/bertopic/ai_services/topic_summarization.py
+++ b/app/aimodels/bertopic/ai_services/topic_summarization.py
@@ -110,15 +110,15 @@ class TopicSummarizer:
         acronym_dictionary = get_acronym_dictionary()
         fixed_docs = []
         for text in docs:
-            if text.endswith('.') or (text != "" and not text.endswith('.')):
-                fixed_docs.append(self.replace_acronyms(
-                    acronym_dictionary, text.rstrip(punctuation)) + '.')
-            elif text.endswith('?'):
+            if text.endswith('?'):
                 fixed_docs.append(self.replace_acronyms(
                     acronym_dictionary, text.rstrip(punctuation)) + '?')
             elif text.endswith('!'):
                 fixed_docs.append(self.replace_acronyms(
                     acronym_dictionary, text.rstrip(punctuation)) + '!')
+            elif text.endswith('.') or (text != "" and not text.endswith('.')):
+                fixed_docs.append(self.replace_acronyms(
+                    acronym_dictionary, text.rstrip(punctuation)) + '.')
             else:
                 fixed_docs.append(text)
         return fixed_docs

--- a/tests/aimodels/bertopic/services/test_topic_summarization.py
+++ b/tests/aimodels/bertopic/services/test_topic_summarization.py
@@ -12,12 +12,20 @@ def test_initalize_llm_invalid():
     assert not topic_summarizer.check_parameters(uuid.uuid4(), MAP_PROMPT_TEMPLATE, COMBINE_PROMPT_TEMPLATE)
     assert topic_summarizer.get_summary(['document']) is None
 
-# test acrnoym expansion
-def test_fix_test():
+# test acronym expansion
+def test_fix_text():
     acronym_dictionary = dict({'PPG': 'Prototype Proving Ground (PPG)'})
     client.post("/v1/upload_acronym_dictionary", params={'acronym_dictionary': json.dumps(acronym_dictionary)})
 
-    documents = ['this is a test of the PPG.']
-    fixed_documents = TopicSummarizer().fix_text(documents)
+    documents = ['this is a test of the PPG.',
+                 'this is a test of the PPG?',
+                 'this is a test of the PPG!',
+                 '']
+    documents_no_punc = ['this is a test of the PPG']
 
-    assert fixed_documents[0] == documents[0].replace('PPG', acronym_dictionary['PPG'])
+    fixed_documents = TopicSummarizer().fix_text(documents)
+    fixed_documents_no_punc = TopicSummarizer().fix_text(documents_no_punc)
+
+    for fixed_doc, doc in zip(fixed_documents, documents):
+        assert fixed_doc == doc.replace('PPG', acronym_dictionary['PPG'])
+    assert fixed_documents_no_punc[0] == documents_no_punc[0].replace('PPG', acronym_dictionary['PPG']) + '.'


### PR DESCRIPTION
#152 
- confirmed app startup and pytests passing
- ran mattermost_topic_summarization.ipynb successfully, but with do_summarization disabled
- increases local coverage of app/aimodels/bertopic/ai_services/topic_summarization.py to
66%
- current P1 coverage at 60.0% (81.7% overall)