### PR TITLE
feat/thread-chats-only

### DIFF
--- a/app/initial_data.py
+++ b/app/initial_data.py
@@ -17,6 +17,7 @@ import ppg.services.mattermost_utils as mattermost_utils
 from ppg.schemas.bertopic.bertopic_embedding_pretrained import BertopicEmbeddingPretrainedCreate, BertopicEmbeddingPretrainedUpdate
 from ppg.schemas.gpt4all.llm_pretrained import LlmPretrainedCreate, LlmPretrainedUpdate
 from ppg.schemas.bertopic.document import DocumentCreate
+from ppg.schemas.mattermost.mattermost_documents import ThreadTypeEnum
 
 from app.aimodels.bertopic.models.bertopic_embedding_pretrained import BertopicEmbeddingPretrainedModel, EmbeddingModelTypeEnum
 from app.aimodels.bertopic.models.document import DocumentModel
@@ -438,7 +439,7 @@ def init_mattermost_documents(db:Session, bot_obj: MattermostUserModel) -> None:
             adf = adf[~adf.id.isin(existing_ids)].drop_duplicates(subset='id')
 
         adf.rename(columns={'id': 'message_id'}, inplace=True)
-        return crud_mattermost.mattermost_documents.create_all_using_df(db, ddf=adf, is_thread=False)
+        return crud_mattermost.mattermost_documents.create_all_using_df(db, ddf=adf, thread_type=ThreadTypeEnum.MESSAGE)
 
 ########## large object uploads ################
 

--- a/app/mattermost/crud/crud_mattermost.py
+++ b/app/mattermost/crud/crud_mattermost.py
@@ -60,12 +60,12 @@ class CRUDMattermostDocument(CRUDBase[MattermostDocumentModel, MattermostDocumen
         # each mattermost document is allowed a single conversation thread
         return db.query(self.model).filter(self.model.message_id == message_id, self.model.is_thread == is_thread).first()
 
-    def get_all_by_message_id(self, db: Session, *, message_id: str, is_thread = False) -> Union[MattermostDocumentModel, None]:
+    def get_all_by_message_id(self, db: Session, *, message_id: str) -> Union[MattermostDocumentModel, None]:
         if not message_id:
             return None
 
         # each mattermost document is allowed a single conversation thread
-        return db.query(self.model).filter(self.model.message_id == message_id, self.model.is_thread == is_thread).all()
+        return db.query(self.model).filter(self.model.message_id == message_id).all()
 
     def get_all_channel_documents(self, db: Session, channels: list[str], history_depth: int = 0, content_filter_list = []) -> Union[list[MattermostDocumentModel], None]:
         stime = datetime.min
@@ -459,7 +459,7 @@ def parse_props(jobj: dict):
         info_type = InfoTypeEnum.ACARS
         msg = parse_props_acars(jobj, title=title)
     elif 'ACARS Free Text' in fallback:
-        info_type = InfoTypeEnum.ACARS
+        info_type = InfoTypeEnum.ACARS_TEXT
         msg = parse_props_acars(jobj, title='ACARS Free Text')
     elif 'NOTAM' in title:
         info_type = InfoTypeEnum.NOTAM

--- a/app/mattermost/models/mattermost_documents.py
+++ b/app/mattermost/models/mattermost_documents.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy import Column, UUID, String, ForeignKey, Enum, JSON, Boolean, UniqueConstraint
 from sqlalchemy.ext.mutable import MutableDict
 from ppg.core.config import OriginationEnum
-from ppg.schemas.mattermost.mattermost_documents import InfoTypeEnum
+from ppg.schemas.mattermost.mattermost_documents import InfoTypeEnum, ThreadTypeEnum
 from app.db.base_class import Base
 from app.core.config import get_originated_from
 
@@ -26,11 +26,11 @@ class MattermostDocumentModel(Base):
     has_reactions = Column(Boolean(), default=False)
     props = Column(MutableDict.as_mutable(JSON))
     doc_metadata = Column(MutableDict.as_mutable(JSON))
-    is_thread = Column(Boolean(), default=False)
+    thread_type = Column(Enum(ThreadTypeEnum), default=ThreadTypeEnum.MESSAGE)
     info_type = Column(Enum(InfoTypeEnum), default=InfoTypeEnum.CHAT)
     originated_from = Column(Enum(OriginationEnum),
                              default=get_originated_from)
 
     # mattermost message IDs must be unique,
     # allow for a single conversation thread for each message
-    __table_args__ = (UniqueConstraint('message_id', 'is_thread', name='_messageid_isthread_uc'),)
+    __table_args__ = (UniqueConstraint('message_id', 'thread_type', name='_messageid_threadtype_uc'),)

--- a/app/mattermost/router.py
+++ b/app/mattermost/router.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 import pandas as pd
 from sqlalchemy.orm import Session
 from ppg.schemas.bertopic.document import DocumentUpdate
-from ppg.schemas.mattermost.mattermost_documents import MattermostDocument, MattermostDocumentUpdate, InfoTypeEnum
+from ppg.schemas.mattermost.mattermost_documents import MattermostDocument, MattermostDocumentUpdate, InfoTypeEnum, ThreadTypeEnum
 from ppg.schemas.mattermost.mattermost_users import MattermostUser
 import ppg.services.mattermost_utils as mattermost_utils
 from app.core.config import settings
@@ -140,7 +140,7 @@ async def upload_mm_channel_docs(request: UploadDocumentRequest, db: Session = D
         adf = adf[~adf.id.isin(existing_ids)].drop_duplicates(subset='id')
 
     adf.rename(columns={'id': 'message_id'}, inplace=True)
-    crud_mattermost.mattermost_documents.create_all_using_df(db, ddf=adf, is_thread=False)
+    crud_mattermost.mattermost_documents.create_all_using_df(db, ddf=adf, thread_type=ThreadTypeEnum.MESSAGE)
 
     return crud_mattermost.mattermost_documents.get_all_channel_documents(db,
                                                                           channels=channel_uuids,
@@ -184,16 +184,20 @@ async def get_mm_channel_docs(team_name: str, channel_name: str,
 class ConversationThreadRequest(BaseModel):
     mattermost_document_ids: list[UUID4] = []
 
+class ConversationThreadResponse(BaseModel):
+    threads: list[MattermostDocument] = []
+    threads_speaker: list[MattermostDocument] = []
+    threads_speaker_persona: list[MattermostDocument] = []
 
 @router.post(
     "/mattermost/conversation_threads",
-    response_model=Union[list[MattermostDocument], HTTPValidationError],
+    response_model=Union[ConversationThreadResponse, HTTPValidationError],
     responses={'422': {'model': HTTPValidationError}},
     summary="Retrieve Mattermost conversation documents",
     response_description="Retrieved Mattermost conversation documents")
 async def convert_conversation_threads(request: ConversationThreadRequest,
                               db: Session = Depends(get_db)) -> (
-    Union[list[MattermostDocument], HTTPValidationError]
+    Union[ConversationThreadResponse, HTTPValidationError]
 ):
     """
     Retrieve Mattermost conversation documents
@@ -214,17 +218,46 @@ async def convert_conversation_threads(request: ConversationThreadRequest,
     conversation_df = crud_mattermost.convert_conversation_threads(df=chat_df)
     conversation_df.rename(columns={'user_uuid': 'user','channel_uuid': 'channel'}, inplace=True)
 
-    document_objs = []
-    new_threads_df = pd.DataFrame()
+    other_mm_doc_objs = [crud_mattermost.mattermost_documents.get_by_message_id(db, message_id=row['message_id'])
+                         for key, row in other_df.iterrows()]
+    if not other_df.empty and (len(other_mm_doc_objs) != len(other_df)):
+        raise HTTPException(status_code=422, detail="Unable to find non chat documents")
+
+    thread_document_objs = ConversationThreadResponse()
+    thread_document_objs.threads = create_conversation_objects(db=db,
+                                                               thread_type=ThreadTypeEnum.THREAD,
+                                                               conversation_df=conversation_df) + other_mm_doc_objs
+
+    thread_document_objs.threads_speaker = create_conversation_objects(db=db,
+                                                               thread_type=ThreadTypeEnum.THREAD_USER,
+                                                               conversation_df=conversation_df) + other_mm_doc_objs
+    thread_document_objs.threads_speaker_persona = create_conversation_objects(db=db,
+                                                               thread_type=ThreadTypeEnum.THREAD_USER_PERSONA,
+                                                               conversation_df=conversation_df) + other_mm_doc_objs
+
+    return thread_document_objs
+
+def create_conversation_objects(db: Session, thread_type: ThreadTypeEnum, conversation_df: pd.DataFrame) -> list[MattermostDocument]:
+
+    thread_document_objs = []
+    thread_df = pd.DataFrame()
+
     for _, row in conversation_df.iterrows():
-        mm_document_obj = crud_mattermost.mattermost_documents.get_by_message_id(db, message_id=row['message_id'], is_thread=True)
+
+        thread_str = row['thread']
+        if thread_type == ThreadTypeEnum.THREAD_USER:
+            thread_str = row['thread_speaker']
+        if thread_type == ThreadTypeEnum.THREAD_USER_PERSONA:
+            thread_str = row['thread_speaker_persona']
+
+        mm_document_obj = crud_mattermost.mattermost_documents.get_by_message_id(db, message_id=row['message_id'], thread_type=thread_type)
 
         # update existing thread
         if mm_document_obj:
             document_obj = crud_document.document.get(db, id=row['document_id'])
             crud_document.document.update(db,
                                  db_obj=document_obj,
-                                 obj_in=DocumentUpdate(text=row['message'],
+                                 obj_in=DocumentUpdate(text=thread_str,
                                                        original_created_time=document_obj.original_created_time))
             updated_mm_doc_obj = crud_mattermost.mattermost_documents.update(db,
                                                                              db_obj=mm_document_obj,
@@ -239,30 +272,23 @@ async def convert_conversation_threads(request: ConversationThreadRequest,
                                                                                 channel=mm_document_obj.channel,
                                                                                 user=mm_document_obj.user,
                                                                                 document=mm_document_obj.document,
-                                                                                is_thread=True,
+                                                                                thread_type=thread_type,
                                                                                 info_type=mm_document_obj.info_type))
-            document_objs = document_objs + [updated_mm_doc_obj]
+            thread_document_objs = thread_document_objs + [updated_mm_doc_obj]
 
         else:
-            new_threads_df = pd.concat([new_threads_df, pd.DataFrame([row])])
+            row['message'] = thread_str
+            thread_df = pd.concat([thread_df, pd.DataFrame([row])])
 
     # create new thread objects
-    if not new_threads_df.empty:
-        new_mm_doc_objs = crud_mattermost.mattermost_documents.create_all_using_df(db, ddf=new_threads_df, is_thread=True)
-        document_objs = document_objs + new_mm_doc_objs
+    if not thread_df.empty:
+        new_mm_doc_objs = crud_mattermost.mattermost_documents.create_all_using_df(db, ddf=thread_df, thread_type=thread_type)
+        thread_document_objs = thread_document_objs + new_mm_doc_objs
 
-    if len(document_objs) != len(conversation_df):
+    if len(thread_document_objs) != len(conversation_df):
         raise HTTPException(status_code=422, detail="Unable to create conversation threads")
 
-    other_mm_doc_objs = [crud_mattermost.mattermost_documents.get_by_message_id(db, message_id=row['message_id'])
-                         for key, row in other_df.iterrows()]
-    if not other_df.empty and (len(other_mm_doc_objs) != len(other_df)):
-        raise HTTPException(status_code=422, detail="Unable to find non chat documents")
-
-    document_objs = document_objs + other_mm_doc_objs
-
-    return document_objs
-
+    return thread_document_objs
 
 class SubstringUploadRequest(BaseModel):
     team_id: str

--- a/app/mattermost/router.py
+++ b/app/mattermost/router.py
@@ -254,13 +254,12 @@ async def convert_conversation_threads(request: ConversationThreadRequest,
     if len(document_objs) != len(conversation_df):
         raise HTTPException(status_code=422, detail="Unable to create conversation threads")
 
-    if not other_df.empty:
-        other_mm_doc_objs = crud_mattermost.mattermost_documents.get_all_by_message_id(other_df.message_id.values)
+    other_mm_doc_objs = [crud_mattermost.mattermost_documents.get_by_message_id(db, message_id=row['message_id'])
+                         for key, row in other_df.iterrows()]
+    if not other_df.empty and (len(other_mm_doc_objs) != len(other_df)):
+        raise HTTPException(status_code=422, detail="Unable to find non chat documents")
 
-        if len(other_mm_doc_objs) != len(other_df):
-            raise HTTPException(status_code=422, detail="Unable to find non chat documents")
-
-        document_objs = document_objs + other_mm_doc_objs
+    document_objs = document_objs + other_mm_doc_objs
 
     return document_objs
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3011,7 +3011,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "ppg-common"
-version = "1.8.0"
+version = "1.9.0"
 description = "A library for PPG common code"
 optional = false
 python-versions = "*"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3011,7 +3011,7 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "ppg-common"
-version = "1.7.0"
+version = "1.8.0"
 description = "A library for PPG common code"
 optional = false
 python-versions = "*"

--- a/ppg-common/ppg/schemas/mattermost/mattermost_documents.py
+++ b/ppg-common/ppg/schemas/mattermost/mattermost_documents.py
@@ -9,6 +9,7 @@ class InfoTypeEnum(str, enum.Enum):
     NOTAM = "notam"
     DATAMINR = "dataminr"
     ACARS = "acars"
+    ACARS_TEXT = "acars_text"
     ENVISION = "envision"
     CAMPS = "camps"
     ARINC = "arinc"

--- a/ppg-common/ppg/schemas/mattermost/mattermost_documents.py
+++ b/ppg-common/ppg/schemas/mattermost/mattermost_documents.py
@@ -15,6 +15,11 @@ class InfoTypeEnum(str, enum.Enum):
     ARINC = "arinc"
     UDL = "udl"
 
+class ThreadTypeEnum(str, enum.Enum):
+    MESSAGE = "message"
+    THREAD = "thread"
+    THREAD_USER = "thread_user"
+    THREAD_USER_PERSONA = "thread_user_persona"
 
 # Shared properties
 class MattermostDocumentBase(BaseModel):
@@ -28,7 +33,7 @@ class MattermostDocumentBase(BaseModel):
     has_reactions: bool
     props: dict
     doc_metadata: dict
-    is_thread: bool
+    thread_type: ThreadTypeEnum
     info_type: InfoTypeEnum
 
 class MattermostDocumentCreate(MattermostDocumentBase):

--- a/ppg-common/setup.py
+++ b/ppg-common/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(name='ppg-common',
-      version='1.7.0',
+      version='1.8.0',
       description='A library for PPG common code',
       url='--',
       author='MIT Lincoln Laboratory',

--- a/ppg-common/setup.py
+++ b/ppg-common/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(name='ppg-common',
-      version='1.8.0',
+      version='1.9.0',
       description='A library for PPG common code',
       url='--',
       author='MIT Lincoln Laboratory',

--- a/tests/mattermost/test_mattermost_crud.py
+++ b/tests/mattermost/test_mattermost_crud.py
@@ -209,9 +209,9 @@ def test_convert_conversation_threads():
     # construct message data frame with reply and convert to conversation thread
     document_df = pd.DataFrame()
     document_df = pd.concat([document_df,  pd.DataFrame(
-        [{'message_id': '1', 'message': msg1, 'root_id': ''}])])
+        [{'message_id': '1', 'message': msg1, 'root_id': '', 'info_type': InfoTypeEnum.CHAT}])])
     document_df = pd.concat([document_df,  pd.DataFrame(
-        [{'message_id': '2', 'message': msg2, 'root_id': '1'}])])
+        [{'message_id': '2', 'message': msg2, 'root_id': '1', 'info_type': InfoTypeEnum.CHAT}])])
 
     conversation_df = crud.convert_conversation_threads(document_df)
 
@@ -229,6 +229,7 @@ def test_parse_props():
                              'author_name': aname,
                              'title': ittl,
                              'text': imsg,
+                             'fallback': '',
                              'fields': []}]}
     itype, omsg = crud.parse_props(jobj)
     emsg = '[%s] %s' % (ittl, imsg)
@@ -275,6 +276,7 @@ def test_parse_props_notam():
                              'author_name': '',
                              'title': ittl,
                              'text': imsg,
+                             'fallback': '',
                              'fields': [{'title': 'Location', 'value': 'KCAT', 'short': True},
                                         {'title': 'Valid', 'value': '4149/0409Z - 4201/2359Z', 'short': True}]}]}
     itype, omsg = crud.parse_props(jobj)
@@ -293,6 +295,7 @@ def test_parse_props_acars():
                              'author_name': '',
                              'title': ittl,
                              'text': imsg,
+                             'fallback': '',
                              'fields': [{'title': 'Tail #', 'value': '8675309', 'short': True},
                                         {'title': 'Mission #', 'value': '8675309', 'short': True},
                                         {'title': 'Callsign', 'value': 'CAT123', 'short': True}]}]}
@@ -311,6 +314,7 @@ def test_parse_props_dataminr():
                              'author_name': 'Dataminr',
                              'title': imsg,
                              'text': '',
+                             'fallback': '',
                              'fields': [{'title': 'Alert Type', 'value': 'Urgent', 'short': False},
                                         {'title': 'Event Time', 'value': '26/06/2024 18:08:19', 'short': False},
                                         {'title': 'Event Location', 'value': 'Lexington, MA USA\n', 'short': False},

--- a/tests/mattermost/test_mattermost_crud.py
+++ b/tests/mattermost/test_mattermost_crud.py
@@ -8,7 +8,7 @@ from app.mattermost.models.mattermost_documents import MattermostDocumentModel
 from app.aimodels.bertopic.models.document import DocumentModel
 from app.aimodels.bertopic.crud import crud_document
 from ppg.core.config import OriginationEnum
-from ppg.schemas.mattermost.mattermost_documents import InfoTypeEnum
+from ppg.schemas.mattermost.mattermost_documents import InfoTypeEnum, ThreadTypeEnum
 
 
 def test_crud_mattermost(db: Session):
@@ -142,8 +142,11 @@ def test_crud_mattermost(db: Session):
                          'props': {'leggo': 'myeggo'},
                          'metadata': {'cuckoo': 'forcocoapuffs'},
                          }])
-    cdf_is_thread = cdf.loc[0, 'root_id'] == db_obj.root_message_id
-    mmdocs = crud.mattermost_documents.create_all_using_df(db, ddf=cdf, is_thread=cdf_is_thread)
+    if cdf.loc[0, 'root_id'] == db_obj.root_message_id:
+        cdf_thread_type = ThreadTypeEnum.THREAD
+    else:
+        cdf_thread_type = ThreadTypeEnum.MESSAGE
+    mmdocs = crud.mattermost_documents.create_all_using_df(db, ddf=cdf, thread_type=cdf_thread_type)
     assert len(mmdocs) == 1
     mmdoc = mmdocs[0]
     newdoc = crud_document.document.get(db, mmdoc.document)
@@ -157,7 +160,7 @@ def test_crud_mattermost(db: Session):
     assert mmdoc.has_reactions == cdf.loc[0, 'has_reactions']
     assert mmdoc.props == cdf.loc[0, 'props']
     assert mmdoc.doc_metadata == cdf.loc[0, 'metadata']
-    assert mmdoc.is_thread == cdf_is_thread
+    assert mmdoc.thread_type == cdf_thread_type
     assert mmdoc.originated_from == settings.originated_from
 
 
@@ -205,18 +208,30 @@ def test_convert_conversation_threads():
 
     msg1 = 'message 1.'
     msg2 = 'message 2.'
+    usr1 = 'user_a'
+    usr2 = 'user_b'
 
     # construct message data frame with reply and convert to conversation thread
     document_df = pd.DataFrame()
-    document_df = pd.concat([document_df,  pd.DataFrame(
-        [{'message_id': '1', 'message': msg1, 'root_id': '', 'info_type': InfoTypeEnum.CHAT}])])
-    document_df = pd.concat([document_df,  pd.DataFrame(
-        [{'message_id': '2', 'message': msg2, 'root_id': '1', 'info_type': InfoTypeEnum.CHAT}])])
+    document_df = pd.concat([document_df,  pd.DataFrame([{'message_id': '1',
+                                                          'message': msg1,
+                                                          'root_id': '',
+                                                          'user_name': usr1,
+                                                          'nickname': usr1,
+                                                          'info_type': InfoTypeEnum.CHAT}])])
+    document_df = pd.concat([document_df,  pd.DataFrame([{'message_id': '2',
+                                                          'message': msg2,
+                                                          'root_id': '1',
+                                                          'user_name': usr2,
+                                                          'nickname': usr2,
+                                                          'info_type': InfoTypeEnum.CHAT}])])
 
     conversation_df = crud.convert_conversation_threads(document_df)
 
     assert len(conversation_df) == (len(document_df) - 1)
-    assert conversation_df['message'].iloc[0] == '%s\n%s' % (msg1, msg2)
+    assert conversation_df['thread'].iloc[0] == '%s\n%s' % (msg1, msg2)
+    assert conversation_df['thread_speaker'].iloc[0] == '%s: %s\n%s: %s' % (usr1, msg1, usr2, msg2)
+    assert conversation_df['thread_speaker_persona'].iloc[0] == '%s (%s): %s\n%s (%s): %s' % (usr1, usr1, msg1, usr2, usr2, msg2)
 
 
 def test_parse_props():

--- a/tests/mattermost/test_mattermost_router.py
+++ b/tests/mattermost/test_mattermost_router.py
@@ -13,6 +13,7 @@ from app.mattermost.models.mattermost_users import MattermostUserModel
 from app.mattermost.models.mattermost_documents import MattermostDocumentModel
 from app.aimodels.bertopic.crud import crud_document
 from ppg.schemas.bertopic.document import DocumentCreate
+from ppg.schemas.mattermost.mattermost_documents import ThreadTypeEnum
 
 @pytest.fixture(scope='module')
 def channel_db_obj(db: Session):
@@ -72,7 +73,7 @@ def mm_db_obj_thread(channel_db_obj: MattermostChannelModel,
                                             hashtags='',
                                             props=dict(),
                                             doc_metadata=dict(),
-                                            is_thread=True)
+                                            thread_type=ThreadTypeEnum.THREAD)
     return crud_mattermost.mattermost_documents.create(db, obj_in=mm_doc_obj_in)
 
 # returns 422
@@ -335,7 +336,9 @@ def test_mattermost_conversation_thread_no_thread(mm_db_obj: MattermostDocumentM
     mm_docs = response.json()
 
     assert response.status_code == 200
-    assert str(mm_db_obj.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs]
+    assert str(mm_db_obj.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs['threads']]
+    assert str(mm_db_obj.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs['threads_speaker']]
+    assert str(mm_db_obj.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs['threads_speaker_persona']]
 
 def test_mattermost_conversation_thread_thread(mm_db_obj_thread: MattermostDocumentModel,
                                                client: TestClient):
@@ -346,4 +349,6 @@ def test_mattermost_conversation_thread_thread(mm_db_obj_thread: MattermostDocum
     mm_docs = response.json()
 
     assert response.status_code == 200
-    assert str(mm_db_obj_thread.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs]
+    assert str(mm_db_obj_thread.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs['threads']]
+    assert str(mm_db_obj_thread.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs['threads_speaker']]
+    assert str(mm_db_obj_thread.message_id) in [mm_doc['message_id'] for mm_doc in mm_docs['threads_speaker_persona']]


### PR DESCRIPTION
- use conversation threads for user chats only https://github.com/MIT-AI-Accelerator/c3po-model-server/issues/240
- add acars_text to info_type to capture air crew "chats" https://github.com/orgs/MIT-AI-Accelerator/projects/3/views/3?pane=issue&itemId=80096759
- add user/persona context to summarization text https://github.com/orgs/MIT-AI-Accelerator/projects/3/views/3?pane=issue&itemId=80614000
- requires DB init and ppg-common build
- confirmed end-to-end and pytests passing